### PR TITLE
change add to tag, and allow tag in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ if (!configFile) {
 debug('args: %j', process.argv);
 debugger;
 var validOps = [
-  'add',
+  'tag',
   'rm',
   'view',
 ];
@@ -49,15 +49,17 @@ if (!conf) {
 }
 
 switch (op) {
-  case 'add':
-    var tag = process.argv[4];
+  case 'tag':
+    var tag = process.argv[4] || conf.tag;
     if (!tag) {
+      console.log('No tag was specified in the config file or as an argument!');
       return printUsage();
     }
-    return operations.add(conf.packages, tag);
+    return operations.tag(conf.packages, tag);
   case 'rm':
-    var tag = process.argv[4];
+    var tag = process.argv[4] || conf.tag;
     if (!tag) {
+      console.log('No tag was specified in the config file or as an argument!');
       return printUsage();
     }
     return operations.rm(conf.packages, tag);

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -4,23 +4,27 @@ var Promise = require('bluebird');
 var debug = require('debug')('dist-tagger');
 var execSync = require('child_process').execSync;
 
-exports.view = function(pkgs, tag) {
-  return Promise.each(pkgs, function(pkg) {
+exports.view = function(pkgs, tag, options) {
+  var opts = options || {};
+  var handler = opts.handler || execHandler;
+  return Promise.map(pkgs, function(pkg) {
     var command = [
       'npm view',
       pkg,
       'dist-tags',
     ].join(' ');
     console.log('%s:', pkg);
-    return execHandler(command);
+    return handler(command);
   });
 };
 
-exports.add = function(pkgs, tag) {
-  return Promise.each(pkgs, function(pkg) {
+exports.tag = function(pkgs, tag, options) {
+  var opts = options || {};
+  var handler = opts.handler || execHandler;
+  return Promise.map(pkgs, function(pkg) {
     var amp = pkg.indexOf('@');
     if (amp < 0) {
-      console.log('Not adding "%s" - no version specified!', pkg);
+      console.log('Not tagging "%s" - no version specified!', pkg);
       return Promise.resolve();
     }
     var command = [
@@ -28,12 +32,14 @@ exports.add = function(pkgs, tag) {
       pkg,
       tag,
     ].join(' ');
-    return execHandler(command);
+    return handler(command);
   });
 };
 
-exports.rm = function(pkgs, tag) {
-  return Promise.each(pkgs, function(pkg) {
+exports.rm = function(pkgs, tag, options) {
+  var opts = options || {};
+  var handler = opts.handler || execHandler;
+  return Promise.map(pkgs, function(pkg) {
     var amp = pkg.indexOf('@');
     // Get substring without version
     var pkgWithoutVer = (amp < 0) ? pkg : pkg.slice(0, amp);
@@ -42,7 +48,7 @@ exports.rm = function(pkgs, tag) {
       pkgWithoutVer,
       tag,
     ].join(' ');
-    return execHandler(command);
+    return handler(command);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,15 @@
   "bin": {
     "dist-tagger": "./index.js"
   },
+  "scripts": {
+    "test": "tap test/test-*.js"
+  },
   "dependencies": {
     "bluebird": "^3.4.6",
     "debug": "^2.2.0",
     "lodash": "^4.16.4"
+  },
+  "devDependencies": {
+    "tap": "^9.0.3"
   }
 }

--- a/test/test-operations.js
+++ b/test/test-operations.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var fmt = require('util').format;
+var operations = require('../lib/operations');
+var tap = require('tap');
+
+tap.test('operations', function(t) {
+
+  var pkgs = [
+    'foo@1.2.3',
+    'bar@2.3.4',
+    'baz@3.4.5',
+  ];
+  var tag = 'snazzy';
+  return Promise.resolve().then(function() {
+    t.test('view', function(t) {
+      return operations.view(pkgs, tag, {
+        handler: fakeExecHandler,
+      }).then(function(results) {
+        t.ok(results, 'received command array');
+        t.equal(results.length, pkgs.length,
+          'correct number of commands received');
+          _.each(results, function(cmd) {
+            var cmdArray = cmd.split(' ');
+            t.comment('command: "' + cmd + '"');
+            var expected = [
+              'npm',
+              'view',
+              'dist-tags',
+            ];
+            checkCommand(t, cmdArray, expected);
+          });
+          t.end();
+        });
+
+    });
+  }).then(function() {
+    t.test('tag', function(t) {
+      return operations.tag(pkgs, tag, {
+        handler: fakeExecHandler,
+      }).then(function(results) {
+        t.ok(results, 'received command array');
+        t.equal(results.length, pkgs.length,
+          'correct number of commands received');
+          _.each(results, function(cmd) {
+            var cmdArray = cmd.split(' ');
+            t.comment('command: "' + cmd + '"');
+            var expected = [
+              'npm',
+              'dist-tag',
+              'add',
+              tag,
+            ];
+            checkCommand(t, cmdArray, expected);
+          });
+          t.end();
+        });
+      });
+    }).then(function() {
+      t.test('rm', function(t) {
+        return operations.tag(pkgs, tag, {
+          handler: fakeExecHandler,
+        }).then(function(results) {
+          t.ok(results, 'received command array');
+          t.equal(results.length, pkgs.length,
+            'correct number of commands received');
+          _.each(results, function(cmd) {
+            var cmdArray = cmd.split(' ');
+            t.comment('command: "' + cmd + '"');
+            var expected = [
+              'npm',
+              'dist-tag',
+              'add',
+              tag,
+            ];
+            checkCommand(t, cmdArray, expected);
+          });
+          t.end();
+        });
+      });
+    });
+});
+
+function checkCommand(t, cmdArray, expected) {
+  _.each(expected, function(item) {
+    t.ok(_.includes(cmdArray, item), fmt('%s was found', item));
+  });
+}
+
+function fakeExecHandler(command) {
+  return Promise.resolve(command);
+};


### PR DESCRIPTION
connected to https://github.com/kjdelisle/dist-tagger/issues/3

If your config has a tag property at top-level, that tag will now
be used. If you specify a tag as an argument at the command line,
it will override the config.